### PR TITLE
Expand textarea instead of scrolling in an already-scrolling window

### DIFF
--- a/index.css
+++ b/index.css
@@ -62,5 +62,4 @@ textarea, .draw {
 textarea {
   position: absolute;
   top: 0;
-  overflow-y: auto;
 }


### PR DESCRIPTION
`textarea` already has an `overflow: hidden` directive above that is overridden here, causing the issue on Linux. 

By making the textarea simply grow in length instead of staying a constant length and scrolling, the window still scrolls as you would expect and scrollbars on the textarea don't mess up the colored highlighting (#6).

This works on Linux, but I haven't tested it on Windows or OS X. 

![2017-04-30-215156_1399x986_scrot](https://cloud.githubusercontent.com/assets/538235/25567892/46b157fa-2def-11e7-8769-dcb4aa84f306.png)
